### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/kalifun/3797a596-4fe3-4cc0-8b7e-78cd36d6344e/d4256518-cf40-43b4-bdc7-f1a43b604fbd/_apis/work/boardbadge/dc897de3-725d-47eb-89c0-395d320c8205)](https://dev.azure.com/kalifun/3797a596-4fe3-4cc0-8b7e-78cd36d6344e/_boards/board/t/d4256518-cf40-43b4-bdc7-f1a43b604fbd/Microsoft.RequirementCategory)
 # gohikvision


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.